### PR TITLE
Add CLI script access for repomap and ast_parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,19 +6,32 @@
 tmp/
 tmp_repos/
 textual/
+output/
 output/*
 !output/.gitkeep
+repomap/output/
+repomap/output/*
+!repomap/output/.gitkeep
 coverage_html_report/
+coverage_html_report/*
 tests/coverage/
+tests/coverage/*
 test_results_*.md
+coverage_summary.md
+test_infrastructure_status.md
 *.bak
 *.bak2
 *.original_backup
-coverage_summary.md
-test_infrastructure_status.md
-repomap/output/repomap_tmp*
 temp_*
 **/temp_*
+bin/
+
+# Keep test files for all languages
+!tests/fixtures/languages/**/*
+!tests/fixtures/sample-code-base/**/*
+!tests/fixtures/watch*
+!tests/data/test*
+!tests/samples/**/*
 
 # Keep .design folder and CLAUDE.md
 !.design/

--- a/ast_parser.py
+++ b/ast_parser.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""
+AST Parser - Main entry point for the command-line tool.
+This script provides a direct way to run the AST Parser tool from the command line.
+"""
+import sys
+import os
+from pathlib import Path
+
+# Add the package directory to the Python path
+current_dir = Path(__file__).resolve().parent
+sys.path.insert(0, str(current_dir))
+
+try:
+    # Import from installed package
+    from repomap.ast_parser import main
+except ImportError:
+    try:
+        # Try direct import from current directory
+        sys.path.insert(0, str(current_dir))
+        from repomap.ast_parser import main
+    except ImportError:
+        print("Error: RepoMap package not found. Please install it first.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    # Pass command-line arguments to the main function
+    sys.exit(main())

--- a/repomap.py
+++ b/repomap.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""
+RepoMap - Main entry point for the command-line tool.
+This script provides a direct way to run the RepoMap tool from the command line.
+"""
+import sys
+import os
+from pathlib import Path
+
+# Add the package directory to the Python path
+current_dir = Path(__file__).resolve().parent
+sys.path.insert(0, str(current_dir))
+
+try:
+    # Import from installed package
+    from repomap import main
+except ImportError:
+    try:
+        # Try direct import from current directory
+        sys.path.insert(0, str(current_dir.parent))
+        from repomap import main
+    except ImportError:
+        print("Error: RepoMap package not found. Please install it first.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    # Pass command-line arguments to the main function
+    sys.exit(main())

--- a/repomap/ast_parser.py
+++ b/repomap/ast_parser.py
@@ -498,22 +498,22 @@ def main():
         epilog="""
 Examples:
   Find a specific function:
-    ast_parser.py myfile.py function_name
+    python-ast-parser myfile.py function_name
   
   Find all callable elements:
-    ast_parser.py myfile.py "*" 
+    python-ast-parser myfile.py "*" 
   
   Get the source code of a class with line numbers:
-    ast_parser.py myfile.py MyClass --get-code --add-line-numbers
+    python-ast-parser myfile.py MyClass --get-code --add-line-numbers
   
   Find all elements (callable and non-callable) with 5 lines of context:
-    ast_parser.py myfile.py "*" --non-callables --get-code --add-context 5
+    python-ast-parser myfile.py "*" --non-callables --get-code --add-context 5
   
   Get only function/class signatures including decorators:
-    ast_parser.py myfile.py "*" --signature-only
+    python-ast-parser myfile.py "*" --signature-only
   
   Get a compact listing of all callable elements:
-    ast_parser.py myfile.py "*" --line-numbers-only
+    python-ast-parser myfile.py "*" --line-numbers-only
 """
     )
     
@@ -583,7 +583,9 @@ Examples:
             for node in results['results']:
                 if node.get('is_callable', True) and node['name'] == sys.argv[2]:
                     print(f"Found Callable '{node['name']}' at lines {node['start_line']}-{node['end_line']}")
-                    sys.exit(0)
+                    return 0
+    
+    return 0
 
 
 if __name__ == "__main__":
@@ -609,4 +611,4 @@ if __name__ == "__main__":
             sys.exit(1)
     else:
         # Use the modern argparse interface
-        main()
+        sys.exit(main())

--- a/scripts/ast_parser.py
+++ b/scripts/ast_parser.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+AST Parser - A command-line script wrapper for running the AST Parser tool.
+This script allows users to run 'python ast_parser.py <args>' directly.
+"""
+import sys
+import os
+from pathlib import Path
+
+# Add parent directory to path for running from any location
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+
+# Import the main function from ast_parser
+try:
+    from repomap.ast_parser import main
+except ImportError:
+    # Fallback if the package isn't installed
+    try:
+        # Try importing from parent directory
+        # This is needed because the first import might fail due to relative imports
+        from repomap.ast_parser import main
+    except ImportError:
+        print("Error: Could not import AST Parser. Please ensure RepoMap is installed.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    # Pass all command-line arguments to the main function
+    sys.exit(main())

--- a/scripts/repomap.py
+++ b/scripts/repomap.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+RepoMap - A command-line script wrapper for running the RepoMap tool.
+This script allows users to run 'python repomap.py <args>' directly.
+"""
+import sys
+import os
+from pathlib import Path
+
+# Add parent directory to path for running from any location
+repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(repo_root))
+
+# Import the main function from repomap
+try:
+    from repomap import main
+except ImportError:
+    # Fallback if the package isn't installed
+    try:
+        # Try importing from parent directory
+        # This is needed because the first import might fail due to relative imports
+        from repomap import main
+    except ImportError:
+        print("Error: Could not import RepoMap. Please ensure it's installed.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    # Pass all command-line arguments to the main function
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,12 @@ setup(
             'ast_parser=repomap.ast_parser:main',
         ],
     },
+    scripts=[
+        'scripts/repomap.py',
+        'scripts/ast_parser.py',
+        'repomap.py',
+        'ast_parser.py',
+    ],
     include_package_data=True,
     package_data={
         'repomap': [

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     entry_points={
         'console_scripts': [
             'repomap=repomap:main',
+            'ast_parser=repomap.ast_parser:main',
         ],
     },
     include_package_data=True,

--- a/tests/test_ast_parser.py
+++ b/tests/test_ast_parser.py
@@ -116,12 +116,27 @@ def standalone_function():
         import subprocess
         
         # Test with a specific function name
-        cmd = [sys.executable, self.temp_py_file.name, "TestClass"]
-        result = subprocess.run(
-            [sys.executable, os.path.join(Path(__file__).parent.parent, "repomap", "ast_parser.py"), 
-             self.temp_py_file.name, "TestClass"],
-            capture_output=True, text=True
-        )
+        try:
+            # First try to use the ast_parser directly as a script
+            ast_parser_path = Path(__file__).parent.parent / "ast_parser.py"
+            if ast_parser_path.exists():
+                result = subprocess.run(
+                    [sys.executable, str(ast_parser_path), self.temp_py_file.name, "TestClass"],
+                    capture_output=True, text=True
+                )
+            else:
+                # Fallback to the module entry point
+                result = subprocess.run(
+                    [sys.executable, os.path.join(Path(__file__).parent.parent, "repomap", "ast_parser.py"), 
+                     self.temp_py_file.name, "TestClass"],
+                    capture_output=True, text=True
+                )
+        except Exception:
+            # Last resort - use the module in package
+            result = subprocess.run(
+                [sys.executable, "-m", "repomap.ast_parser", self.temp_py_file.name, "TestClass"],
+                capture_output=True, text=True
+            )
         
         # Check if the output matches what section_splitting.py expects
         self.assertEqual(result.returncode, 0)

--- a/tests/test_ast_parser_advanced.py
+++ b/tests/test_ast_parser_advanced.py
@@ -220,7 +220,13 @@ if __name__ == "__main__":
 """)
 
         # Path to the ast_parser.py script
-        self.ast_parser_path = Path(__file__).parent.parent / "ast_parser.py"
+        # Try different possible locations
+        ast_parser_path = Path(__file__).parent.parent / "ast_parser.py"
+        if ast_parser_path.exists():
+            self.ast_parser_path = ast_parser_path
+        else:
+            # Fallback to module path
+            self.ast_parser_path = Path(__file__).parent.parent / "repomap" / "ast_parser.py"
     
     def tearDown(self):
         """Clean up test fixtures."""
@@ -396,12 +402,22 @@ if __name__ == "__main__":
         
     def run_ast_parser(self, *args):
         """Run the ast_parser.py script with the given arguments."""
-        cmd = [sys.executable, str(self.ast_parser_path), str(self.test_file_path)] + list(args)
-        result = subprocess.run(cmd, 
-                               capture_output=True, 
-                               text=True,
-                               check=False)
-        return result
+        try:
+            # First try with direct script
+            cmd = [sys.executable, str(self.ast_parser_path), str(self.test_file_path)] + list(args)
+            result = subprocess.run(cmd, 
+                                   capture_output=True, 
+                                   text=True,
+                                   check=False)
+            return result
+        except Exception:
+            # Fallback to module import
+            cmd = [sys.executable, "-m", "repomap.ast_parser", str(self.test_file_path)] + list(args)
+            result = subprocess.run(cmd, 
+                                   capture_output=True, 
+                                   text=True, 
+                                   check=False)
+            return result
         
     def test_cli_pattern_matching_advanced(self):
         """Test pattern matching for advanced constructs."""
@@ -434,7 +450,14 @@ class TestAstParserEdgeCases(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.temp_dir = tempfile.TemporaryDirectory()
-        self.ast_parser_path = Path(__file__).parent.parent / "ast_parser.py"
+        # Path to the ast_parser.py script
+        # Try different possible locations
+        ast_parser_path = Path(__file__).parent.parent / "ast_parser.py"
+        if ast_parser_path.exists():
+            self.ast_parser_path = ast_parser_path
+        else:
+            # Fallback to module path
+            self.ast_parser_path = Path(__file__).parent.parent / "repomap" / "ast_parser.py"
         
     def tearDown(self):
         """Clean up test fixtures."""
@@ -479,12 +502,22 @@ class TestAstParserEdgeCases(unittest.TestCase):
         
     def run_ast_parser(self, file_path, *args):
         """Run the ast_parser.py script with the given arguments."""
-        cmd = [sys.executable, str(self.ast_parser_path), str(file_path)] + list(args)
-        result = subprocess.run(cmd, 
-                               capture_output=True, 
-                               text=True,
-                               check=False)
-        return result
+        try:
+            # First try with direct script
+            cmd = [sys.executable, str(self.ast_parser_path), str(file_path)] + list(args)
+            result = subprocess.run(cmd, 
+                                   capture_output=True, 
+                                   text=True,
+                                   check=False)
+            return result
+        except Exception:
+            # Fallback to module import
+            cmd = [sys.executable, "-m", "repomap.ast_parser", str(file_path)] + list(args)
+            result = subprocess.run(cmd, 
+                                   capture_output=True, 
+                                   text=True, 
+                                   check=False)
+            return result
         
     def test_cli_error_handling(self):
         """Test CLI error handling."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,12 +30,24 @@ class TestCLI(unittest.TestCase):
     def test_cli_help(self):
         """Test CLI help output"""
         # Use subprocess to run the CLI with --help
-        result = subprocess.run(
-            [sys.executable, "-m", "repomap", "--help"],
-            capture_output=True,
-            text=True,
-            check=False
-        )
+        # Try both the module approach and direct script approach
+        try:
+            result = subprocess.run(
+                [sys.executable, "-m", "repomap", "--help"],
+                capture_output=True,
+                text=True,
+                check=False
+            )
+        except Exception:
+            # Fallback to direct script approach
+            repo_root = Path(__file__).parent.parent
+            script_path = repo_root / "repomap.py"
+            result = subprocess.run(
+                [sys.executable, str(script_path), "--help"],
+                capture_output=True,
+                text=True, 
+                check=False
+            )
 
         # Check that it ran successfully
         self.assertEqual(result.returncode, 0)
@@ -54,12 +66,24 @@ class TestCLI(unittest.TestCase):
     def test_cli_debug(self):
         """Test CLI debug output"""
         # Use subprocess to run with --debug
-        result = subprocess.run(
-            [sys.executable, "-m", "repomap", "--debug", str(PYTHON_SAMPLE)],
-            capture_output=True,
-            text=True,
-            check=False
-        )
+        # Try both the module approach and direct script approach
+        try:
+            result = subprocess.run(
+                [sys.executable, "-m", "repomap", "--debug", str(PYTHON_SAMPLE)],
+                capture_output=True,
+                text=True,
+                check=False
+            )
+        except Exception:
+            # Fallback to direct script approach
+            repo_root = Path(__file__).parent.parent
+            script_path = repo_root / "repomap.py"
+            result = subprocess.run(
+                [sys.executable, str(script_path), "--debug", str(PYTHON_SAMPLE)],
+                capture_output=True,
+                text=True,
+                check=False
+            )
 
         # Check that it ran successfully (should return 1 because of no repo map)
         # We're just checking the debug output works


### PR DESCRIPTION
## Summary
- Added wrapper scripts in root and scripts/ directories to support running `python repomap.py` and `python ast_parser.py`
- Updated setup.py to include these scripts in pip installation
- Modified tests to handle multiple script locations through fallback mechanisms
- Updated .gitignore to exclude output/cache files while preserving test fixtures
- Fixed multiple tests to work with either module or direct script import

## Test plan
- Verified command-line functionality with both approaches
- Ensured test fixtures are properly tracked with git
- All tests pass with updated script paths
- Installation includes both CLI approaches: entry_point and direct script

🤖 Generated with [Claude Code](https://claude.ai/code)